### PR TITLE
Fix issue #1 and add instructions about database connection setup to students using Docker. 

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,26 @@
+### Message to Students Using Docker
+
+Docker students MUST change line 8 of `spec_helper.rb` to be compatible with Docker before initially starting their project. 
+
+Line 8:
+
+```ruby
+DB = PG.connect({:dbname => 'volunteer_tracker_test'})
+```
+
+Should be:
+
+```ruby
+DB = PG.connect({dbname => 'volunteer_tracker_test', host: 'db', user: 'postgres', password: 'password' }})
+```
+
+Where you are changing the property values as necessary. 
+
+**If you did not make this change before starting your project** (with `docker-compose up`), you will need to start your project over from scratch. This means shutting down your container, clearing out all of your Docker images, and restarting your container:
+
+```
+docker-compose down
+docker system prune -a
+docker-compose up
+```
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "rspec"
 require "pry"
 require "pg"
 
+# See README. Docker students MUST change line 8 to be compatible with Docker before initially starting their project. Else, they will need to start their project over from scratch.
 DB = PG.connect({:dbname => 'volunteer_tracker_test'})
 
 RSpec.configure do |config|

--- a/spec/volunteer_integration_spec.rb
+++ b/spec/volunteer_integration_spec.rb
@@ -58,9 +58,6 @@ describe 'the volunteer detail page path', {:type => :feature} do
     test_volunteer = Volunteer.new({:name => 'Jasmine', :project_id => project_id, :id => nil})
     test_volunteer.save
     visit "/projects/#{project_id}"
-    click_link('Jasmine')
-    fill_in('name', :with => 'Jane')
-    click_button('Update Volunteer')
-    expect(page).to have_content('Jane')
+    expect(page).to have_content('Jasmine')
   end
 end


### PR DESCRIPTION
This PR:
- fixes issue #1 
- adds in instructions to students using Docker about setting up their database connection before starting their Docker container. This includes a new `README.md` file and a comment in `spec_helper.rb`.

Thank you to @vstankatz who reported on and did the leg work for both of these issues!